### PR TITLE
Add SQL query POST route

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -1,9 +1,28 @@
-from flask import Blueprint, render_template
+import sqlite3
+from flask import Blueprint, render_template, request
+from init_db import DB_PATH
 
 main = Blueprint('main', __name__)
 
-@main.route('/')
+@main.route('/', methods=['GET', 'POST'])
 def index():
-    return "SQL Playground is running."
+    results = None
+    columns = []
+    error = None
+    if request.method == 'POST':
+        query = request.form.get('query')
+        try:
+            with sqlite3.connect(DB_PATH) as conn:
+                cursor = conn.execute(query)
+                if cursor.description:
+                    columns = [d[0] for d in cursor.description]
+                    results = cursor.fetchall()
+                else:
+                    # Non-select queries
+                    conn.commit()
+                    results = []
+        except Exception as e:
+            error = str(e)
+    return render_template('index.html', results=results, columns=columns, error=error)
 
 

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -1,0 +1,40 @@
+<!doctype html>
+<html>
+<head>
+    <title>SQL Playground</title>
+</head>
+<body>
+    <h1>SQL Playground</h1>
+    <form method="post" action="/">
+        <textarea name="query" rows="4" cols="80"></textarea><br>
+        <input type="submit" value="Execute">
+    </form>
+    {% if error %}
+    <p style="color:red;">{{ error }}</p>
+    {% endif %}
+    {% if results is not none %}
+        {% if results %}
+        <table border="1">
+            <thead>
+                <tr>
+                    {% for col in columns %}
+                    <th>{{ col }}</th>
+                    {% endfor %}
+                </tr>
+            </thead>
+            <tbody>
+                {% for row in results %}
+                <tr>
+                    {% for value in row %}
+                    <td>{{ value }}</td>
+                    {% endfor %}
+                </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+        {% else %}
+        <p>No results.</p>
+        {% endif %}
+    {% endif %}
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add SQL query execution logic in `routes.py`
- render query form and results via new `index.html`

## Testing
- `python -m py_compile app/*.py init_db.py run.py`
- manual Flask test client GET/POST requests

------
https://chatgpt.com/codex/tasks/task_e_6840a8d9d2e88321baa75d6d0ca55733