### PR TITLE
Increase schema diagram font size

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -42,7 +42,18 @@
     })
     new EditorView({ state, parent: editorContainer })
 
-    mermaid.initialize({ startOnLoad: false, themeVariables: { fontSize: '16px' } })
+    mermaid.initialize({
+      startOnLoad: false,
+      themeVariables: { fontSize: '20px' },
+      er: {
+        fontSize: 20,
+        minEntityWidth: 120,
+        minEntityHeight: 80,
+        entityPadding: 15
+      },
+      nodeSpacing: 40,
+      rankSpacing: 40
+    })
     fetch('http://localhost:5000/api/schema')
       .then((r) => r.json())
       .then((data) => {
@@ -119,9 +130,10 @@
     text-align: left;
   }
   .schema :global(svg) {
-    max-width: 100%;
+    width: 100%;
+    height: auto;
   }
   .schema :global(svg text) {
-    font-size: 16px;
+    font-size: 20px;
   }
 </style>


### PR DESCRIPTION
## Summary
- increase Mermaid font size when rendering schema diagrams
- add CSS rule to boost SVG text size

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_6840beb55c808321a41687548ad74db4