### PR TITLE
Fix schema diagram modal resizing and reopen

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -46,11 +46,11 @@
 
     mermaid.initialize({
       startOnLoad: false,
-      themeVariables: { fontSize: '20px' },
+      themeVariables: { fontSize: '32px' },
       er: {
-        fontSize: 20,
-        minEntityWidth: 120,
-        minEntityHeight: 80,
+        fontSize: 32,
+        minEntityWidth: 200,
+        minEntityHeight: 120,
         entityPadding: 15
       },
       nodeSpacing: 40,
@@ -93,6 +93,8 @@
 
   function closeSchema() {
     showSchema = false
+    schemaInitialized = false
+    if (schemaContainer) schemaContainer.innerHTML = ''
   }
 </script>
 
@@ -157,7 +159,7 @@
     height: auto;
   }
   .schema :global(svg text) {
-    font-size: 20px;
+    font-size: 32px;
   }
 
   .modal-overlay {


### PR DESCRIPTION
## Summary
- enlarge database diagram text size
- ensure schema diagram rerenders when modal is reopened

## Testing
- `npm run check`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6840c71f35e88321987529a035f58455