### PR TITLE
Increase ER diagram size

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -153,10 +153,13 @@
   .schema {
     margin-top: 1rem;
     text-align: left;
+    overflow: auto;
   }
   .schema :global(svg) {
     width: 100%;
     height: auto;
+    transform: scale(1.5);
+    transform-origin: top left;
   }
   .schema :global(svg text) {
     font-size: 32px;


### PR DESCRIPTION
## Summary
- enlarge the ER diagram by scaling the SVG
- allow scroll in schema modal for oversized diagrams

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_6840c8c7272c83218b20bd5b15a0dd85