### PR TITLE
Increase ER diagram size

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -153,10 +153,13 @@
   .schema {
     margin-top: 1rem;
     text-align: left;
+    overflow: auto;
   }
   .schema :global(svg) {
     width: 100%;
     height: auto;
+    transform: scale(1.5);
+    transform-origin: top left;
   }
   .schema :global(svg text) {
     font-size: 32px;
@@ -179,8 +182,10 @@
     background: var(--background, #fff);
     padding: 1rem;
     border-radius: 8px;
-    max-width: 90%;
-    max-height: 90%;
+    width: 95%;
+    height: 95%;
+    max-width: none;
+    max-height: none;
     overflow: auto;
   }
 


### PR DESCRIPTION
## Summary
- enlarge the ER diagram by scaling the SVG
- allow scroll in schema modal for oversized diagrams
- expand schema modal size to reduce scrollbars

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_6840c8c7272c83218b20bd5b15a0dd85