### PR TITLE
Move show schema button

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -13,6 +13,7 @@
   let results: any[] | null = null
   let columns: string[] = []
   let error: string | null = null
+  let showSchema = false
 
   function generateMermaid(tables: { name: string; columns: { name: string; type: string }[] }[]) {
     const lines = ['erDiagram']
@@ -65,6 +66,10 @@
       })
   })
 
+  function toggleSchema() {
+    showSchema = !showSchema
+  }
+
   async function execute() {
     error = null
     results = null
@@ -85,6 +90,9 @@
   <div class="editor" bind:this={editorContainer}></div>
   <br>
   <button on:click={execute}>Execute</button>
+  <button on:click={toggleSchema} style="margin-left: 1rem">
+    {showSchema ? 'Hide Schema' : 'Show Database Schema'}
+  </button>
   {#if error}
     <p style="color:red">{error}</p>
   {/if}
@@ -112,8 +120,10 @@
       <p>No results.</p>
     {/if}
   {/if}
-  <h2>Database Schema</h2>
-  <div class="schema" bind:this={schemaContainer}></div>
+  {#if showSchema}
+    <h2>Database Schema</h2>
+    <div class="schema" bind:this={schemaContainer}></div>
+  {/if}
 </main>
 
 <style>


### PR DESCRIPTION
## Summary
- add toggle state for schema rendering
- show database schema button next to Execute

## Testing
- `npm install`
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_6840da04938c83218ce7b6f05f5e351b