### PR TITLE
Move admin UI to password-protected route

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,3 +33,4 @@ This project is useful for learning, demonstrations, and experimenting with SQL 
 4. In `frontend/`, run `npm install` to install frontend packages.
 5. Launch the Svelte app with `npm run dev` and open [http://127.0.0.1:5173/](http://127.0.0.1:5173/).
 6. Admin endpoints require the `X-Admin-Password` header. The default password is `admin123`.
+7. The admin interface is available at `/admin` and requires the same password.

--- a/frontend/src/Admin.svelte
+++ b/frontend/src/Admin.svelte
@@ -1,0 +1,88 @@
+<script lang="ts">
+  let password = ''
+  let dbs: string[] = []
+  let activeDb = ''
+  let uploadFile: File | null = null
+  let error: string | null = null
+  let loggedIn = false
+
+  async function login() {
+    error = null
+    const res = await fetch('http://localhost:5000/api/admin/databases', {
+      headers: { 'X-Admin-Password': password }
+    })
+    if (!res.ok) {
+      error = 'Invalid password'
+      loggedIn = false
+      return
+    }
+    const data = await res.json()
+    dbs = data.databases
+    activeDb = data.active
+    loggedIn = true
+  }
+
+  async function upload() {
+    if (!uploadFile) return
+    const fd = new FormData()
+    fd.append('file', uploadFile)
+    await fetch('http://localhost:5000/api/admin/upload', {
+      method: 'POST',
+      headers: { 'X-Admin-Password': password },
+      body: fd
+    })
+    await login()
+  }
+
+  async function activate(name: string) {
+    await fetch('http://localhost:5000/api/admin/activate', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Admin-Password': password
+      },
+      body: JSON.stringify({ name })
+    })
+    await login()
+  }
+</script>
+
+<main>
+  <h1>Admin</h1>
+  {#if !loggedIn}
+    <input
+      type="password"
+      placeholder="Password"
+      bind:value={password}
+    />
+    <button on:click={login}>Login</button>
+    {#if error}
+      <p style="color:red">{error}</p>
+    {/if}
+  {:else}
+    <button on:click={() => (loggedIn = false)}>Logout</button>
+    <p>Active DB: {activeDb}</p>
+    <ul>
+      {#each dbs as db}
+        <li>
+          {db}
+          {#if db !== activeDb}
+            <button on:click={() => activate(db)}>Activate</button>
+          {/if}
+        </li>
+      {/each}
+    </ul>
+    <input type="file" accept=".db" on:change={(e) => (uploadFile = e.target.files[0])} />
+    <button on:click={upload}>Upload</button>
+  {/if}
+</main>
+
+<style>
+  .admin {
+    margin-top: 1rem;
+    text-align: left;
+  }
+  input[type='password'] {
+    margin-right: 0.5rem;
+  }
+</style>

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -17,13 +17,6 @@
   let results: any[] | null = null
   let columns: string[] = []
   let error: string | null = null
-  let showSchema = false
-  let adminMode = false
-  let adminPassword = ''
-  let dbs: string[] = []
-  let activeDb = ''
-  let uploadFile: File | null = null
-  let adminError: string | null = null
 
   function generateMermaid(tables: { name: string; columns: { name: string; type: string }[] }[]) {
     const lines = ['erDiagram']
@@ -89,43 +82,6 @@
       })
   }
 
-  async function loadDatabases() {
-    adminError = null
-    const res = await fetch('http://localhost:5000/api/admin/databases', {
-      headers: { 'X-Admin-Password': adminPassword }
-    })
-    if (!res.ok) {
-      adminError = 'Invalid password'
-      return
-    }
-    const data = await res.json()
-    dbs = data.databases
-    activeDb = data.active
-  }
-
-  async function upload() {
-    if (!uploadFile) return
-    const fd = new FormData()
-    fd.append('file', uploadFile)
-    await fetch('http://localhost:5000/api/admin/upload', {
-      method: 'POST',
-      headers: { 'X-Admin-Password': adminPassword },
-      body: fd
-    })
-    await loadDatabases()
-  }
-
-  async function activate(name: string) {
-    await fetch('http://localhost:5000/api/admin/activate', {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        'X-Admin-Password': adminPassword
-      },
-      body: JSON.stringify({ name })
-    })
-    await loadDatabases()
-  }
 
   async function execute() {
     error = null
@@ -201,37 +157,6 @@
     </div>
   {/if}
 
-  <button on:click={() => (adminMode = !adminMode)} style="margin-top: 1rem">
-    {adminMode ? 'Close Admin' : 'Admin Mode'}
-  </button>
-  {#if adminMode}
-    <div class="admin">
-      <input
-        type="password"
-        placeholder="Password"
-        bind:value={adminPassword}
-      />
-      <button on:click={loadDatabases}>Load</button>
-      {#if adminError}
-        <p style="color:red">{adminError}</p>
-      {/if}
-      {#if dbs.length}
-        <p>Active DB: {activeDb}</p>
-        <ul>
-          {#each dbs as db}
-            <li>
-              {db}
-              {#if db !== activeDb}
-                <button on:click={() => activate(db)}>Activate</button>
-              {/if}
-            </li>
-          {/each}
-        </ul>
-      {/if}
-      <input type="file" accept=".db" on:change={(e) => (uploadFile = e.target.files[0])} />
-      <button on:click={upload}>Upload</button>
-    </div>
-  {/if}
 </main>
 
 <style>
@@ -281,12 +206,5 @@
 
   .close {
     float: right;
-  }
-  .admin {
-    margin-top: 1rem;
-    text-align: left;
-  }
-  .admin input[type='password'] {
-    margin-right: 0.5rem;
   }
 </style>

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -1,9 +1,13 @@
 import { mount } from 'svelte'
 import './app.css'
 import App from './App.svelte'
+import Admin from './Admin.svelte'
 
-const app = mount(App, {
-  target: document.getElementById('app')!,
+const target = document.getElementById('app')!
+const Component = window.location.pathname === '/admin' ? Admin : App
+
+const app = mount(Component, {
+  target,
 })
 
 export default app


### PR DESCRIPTION
## Summary
- move all admin features to new `Admin.svelte`
- remove admin controls from `App.svelte`
- load `Admin.svelte` when path is `/admin`
- mention new location in README

## Testing
- `python -m py_compile run.py app/*.py`
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840df734bd083219b2fa171686962e0