### PR TITLE
Add database delete option to admin

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -95,3 +95,22 @@ def admin_activate():
             return jsonify({'error': 'not found'}), 404
     set_active_db(candidate)
     return jsonify({'status': 'ok'})
+
+
+@main.route('/api/admin/delete', methods=['POST'])
+def admin_delete():
+    """Delete a stored database."""
+    require_admin(request)
+    data = request.get_json(force=True)
+    name = data.get('name')
+    if not name:
+        return jsonify({'error': 'missing name'}), 400
+    if name == os.path.basename(DEFAULT_DB):
+        return jsonify({'error': 'cannot delete default'}), 400
+    path = os.path.join(UPLOAD_DIR, name)
+    if not os.path.exists(path):
+        return jsonify({'error': 'not found'}), 404
+    if os.path.samefile(path, get_active_db()):
+        set_active_db(DEFAULT_DB)
+    os.remove(path)
+    return jsonify({'status': 'ok'})

--- a/frontend/src/Admin.svelte
+++ b/frontend/src/Admin.svelte
@@ -45,6 +45,18 @@
     })
     await login()
   }
+
+  async function remove(name: string) {
+    await fetch('http://localhost:5000/api/admin/delete', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Admin-Password': password
+      },
+      body: JSON.stringify({ name })
+    })
+    await login()
+  }
 </script>
 
 <main>
@@ -68,6 +80,9 @@
           {db}
           {#if db !== activeDb}
             <button on:click={() => activate(db)}>Activate</button>
+          {/if}
+          {#if db !== 'playground.db'}
+            <button on:click={() => remove(db)}>Delete</button>
           {/if}
         </li>
       {/each}


### PR DESCRIPTION
## Summary
- allow deleting database files via new `/api/admin/delete` endpoint
- show delete button in admin UI

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `npm run check` *(fails: svelte-check found 2 errors and 5 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_684159eea72c83219d9b64f529efdd43