### PR TITLE
Fix admin page SQL editor initialization

### DIFF
--- a/frontend/src/Admin.svelte
+++ b/frontend/src/Admin.svelte
@@ -1,9 +1,10 @@
 <script lang="ts">
-  import { EditorState } from '@codemirror/state'
-  import { EditorView, basicSetup } from 'codemirror'
-  import { sql } from '@codemirror/lang-sql'
-  import { keymap } from '@codemirror/view'
-  import { acceptCompletion } from '@codemirror/autocomplete'
+import { EditorState } from '@codemirror/state'
+import { EditorView, basicSetup } from 'codemirror'
+import { sql } from '@codemirror/lang-sql'
+import { keymap } from '@codemirror/view'
+import { acceptCompletion } from '@codemirror/autocomplete'
+import { afterUpdate } from 'svelte'
 
   let password = ''
   let dbs: string[] = []
@@ -100,7 +101,9 @@
     editorInitialized = true
   }
 
-  $: if (loggedIn) initEditor()
+  afterUpdate(() => {
+    if (loggedIn) initEditor()
+  })
 </script>
 
 <main>


### PR DESCRIPTION
## Summary
- run SQL editor setup after DOM updates using `afterUpdate`

## Testing
- `npm run --prefix frontend check`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684162df804883218a91dfc033008ec4