### PR TITLE
Add SQL schema file upload for DB creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,4 +35,4 @@ This project is useful for learning, demonstrations, and experimenting with SQL 
 5. Launch the Svelte app with `npm run dev` and open [http://127.0.0.1:5173/](http://127.0.0.1:5173/).
 6. Admin endpoints require the `X-Admin-Password` header. The default password is `admin123`.
 7. The admin interface is available at `/admin` and requires the same password.
-8. The admin page also lets you create a new database by entering SQL.
+8. The admin page also lets you create a new database by entering SQL or uploading a schema file.


### PR DESCRIPTION
## Summary
- allow admins to create a database from an uploaded SQL file
- update admin UI with file upload option
- document new admin feature

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `npm run check` in `frontend/`

------
https://chatgpt.com/codex/tasks/task_e_684164f3bc208321af1000568df24cdd