### PR TITLE
Add dotenv support for OpenAI key

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,7 @@ coverage/
 *.sqlite
 *.db
 *.sqlite3
+generated_init_db.py
 
 # Optional: macOS crash reports
 *.crash

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ This project is useful for learning, demonstrations, and experimenting with SQL 
 * [x] UML-style schema viewer powered by Mermaid
 * [x] Password protected admin mode to manage databases
 * [x] Create databases from SQL scripts in the admin interface
+* [x] Generate databases using OpenAI (via admin UI or `openai_db_creator.py`)
 
 ## Setup Instructions
 
@@ -36,3 +37,4 @@ This project is useful for learning, demonstrations, and experimenting with SQL 
 6. Admin endpoints require the `X-Admin-Password` header. The default password is `admin123`.
 7. The admin interface is available at `/admin` and requires the same password.
 8. The admin page also lets you create a new database by entering SQL or uploading a schema file.
+9. For OpenAI-assisted database generation create a `.env` file with `OPENAI_API_KEY=<your key>` and either run `python openai_db_creator.py` or use the admin page's "Create With OpenAI" form.

--- a/app/routes.py
+++ b/app/routes.py
@@ -167,3 +167,27 @@ def admin_create_from_file():
             os.remove(dest)
         return jsonify({'error': str(e)}), 400
     return jsonify({'status': 'ok'})
+
+
+@main.route('/api/admin/openai_create', methods=['POST'])
+def admin_openai_create():
+    """Create a new database using OpenAI-generated code."""
+    require_admin(request)
+    data = request.get_json(force=True)
+    name = data.get('name')
+    prompt = data.get('prompt')
+    if not name or not name.endswith('.db'):
+        return jsonify({'error': 'invalid name'}), 400
+    if not prompt:
+        return jsonify({'error': 'missing prompt'}), 400
+    filename = secure_filename(name)
+    dest = os.path.join(UPLOAD_DIR, filename)
+    if os.path.exists(dest):
+        return jsonify({'error': 'already exists'}), 400
+    from openai_db_creator import create_database
+    success, msg = create_database(prompt, dest)
+    if not success:
+        if os.path.exists(dest):
+            os.remove(dest)
+        return jsonify({'error': msg}), 400
+    return jsonify({'status': 'ok', 'message': msg})

--- a/frontend/src/Admin.svelte
+++ b/frontend/src/Admin.svelte
@@ -15,6 +15,7 @@ import { afterUpdate } from 'svelte'
   let createName = ''
   let createSQL = ''
   let schemaFile: File | null = null
+  let openaiRequest = ''
   let editorContainer: HTMLDivElement
   let editorInitialized = false
 
@@ -98,6 +99,20 @@ import { afterUpdate } from 'svelte'
     await login()
   }
 
+  async function createDbWithOpenAI() {
+    await fetch('http://localhost:5000/api/admin/openai_create', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Admin-Password': password
+      },
+      body: JSON.stringify({ name: createName, prompt: openaiRequest })
+    })
+    createName = ''
+    openaiRequest = ''
+    await login()
+  }
+
   function initEditor() {
     if (editorInitialized || !editorContainer) return
     const state = EditorState.create({
@@ -167,20 +182,27 @@ import { afterUpdate } from 'svelte'
       bind:value={createName}
     />
     <div class="editor" bind:this={editorContainer}></div>
-    <button on:click={createDb}>Create</button>
-    <div class="file-create">
-      <input
-        type="file"
-        accept=".sql,.txt"
+      <button on:click={createDb}>Create</button>
+      <div class="file-create">
+        <input
+          type="file"
+          accept=".sql,.txt"
         on:change={(e) => {
           const input = e.target as HTMLInputElement
           schemaFile = input.files?.[0] || null
         }}
-      />
-      <button on:click={createDbFromFile}>Create From File</button>
-    </div>
-  {/if}
-</main>
+        />
+        <button on:click={createDbFromFile}>Create From File</button>
+      </div>
+      <h2>Create With OpenAI</h2>
+      <textarea
+        rows="3"
+        placeholder="Describe the desired database"
+        bind:value={openaiRequest}
+      ></textarea>
+      <button on:click={createDbWithOpenAI}>Create With OpenAI</button>
+    {/if}
+  </main>
 
 <style>
   .admin {
@@ -202,6 +224,11 @@ import { afterUpdate } from 'svelte'
   }
 
   .file-create {
+    margin-top: 0.5rem;
+  }
+
+  textarea {
+    width: 100%;
     margin-top: 0.5rem;
   }
 </style>

--- a/openai_db_creator.py
+++ b/openai_db_creator.py
@@ -1,0 +1,79 @@
+import os
+import subprocess
+from pathlib import Path
+
+import openai
+from dotenv import load_dotenv
+
+# Load environment variables from a .env file if present
+load_dotenv()
+
+TEMPLATE_PATH = Path(__file__).parent / "init_db.py"
+OUTPUT_SCRIPT = Path("generated_init_db.py")
+
+
+def create_database(user_request: str, db_path: str) -> tuple[bool, str]:
+    """Generate and run a DB init script via OpenAI."""
+
+    api_key = os.getenv("OPENAI_API_KEY")
+    if not api_key:
+        return False, "OPENAI_API_KEY environment variable not set"
+
+    openai.api_key = api_key
+
+    with open(TEMPLATE_PATH, "r", encoding="utf-8") as f:
+        template = f.read()
+
+    prompt = (
+        "You are an assistant that generates Python scripts to create SQLite databases.\n"
+        "Use the following template as a starting point.\n"
+        "The script should write to the path provided in DB_PATH and, if requested, populate it with random data.\n"
+        "Template:\n" + template + "\n" +
+        "User request:\n" + user_request + "\n"
+        "Provide only the Python code in your response."
+    )
+
+    try:
+        response = openai.ChatCompletion.create(
+            model="gpt-3.5-turbo",
+            messages=[{"role": "user", "content": prompt}],
+            temperature=0.2,
+        )
+    except Exception as e:
+        return False, f"OpenAI API call failed: {e}"
+
+    code = response.choices[0].message.content
+    try:
+        OUTPUT_SCRIPT.write_text(code, encoding="utf-8")
+    except Exception as e:
+        return False, f"Failed to save generated script: {e}"
+
+    env = os.environ.copy()
+    env["DB_PATH"] = db_path
+
+    try:
+        subprocess.run(["python", str(OUTPUT_SCRIPT)], check=True, env=env)
+    except subprocess.CalledProcessError as e:
+        return False, f"Generated script failed: {e}"
+
+    if Path(db_path).exists():
+        return True, f"Database created at {db_path}"
+    return False, "Script ran but database was not created"
+
+
+def main():
+    target_db = input("Name of the database file to create (e.g. new.db): ").strip()
+    if not target_db:
+        print("No database name provided")
+        return
+
+    user_req = input(
+        "Describe the desired database schema and whether to populate it with random data:\n"
+    )
+
+    success, msg = create_database(user_req, target_db)
+    print(msg)
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
 flask
 flask-cors
+openai
+python-dotenv


### PR DESCRIPTION
## Summary
- load environment variables from a `.env` file in `openai_db_creator.py`
- document `.env` usage for the OpenAI API key
- require `python-dotenv`

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile openai_db_creator.py app/*.py`


------
https://chatgpt.com/codex/tasks/task_e_68416755ebd48321b52ff665dc6f90da