### PR TITLE
Load admin password from dotenv

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,8 @@ This project is useful for learning, demonstrations, and experimenting with SQL 
 3. Start the Flask API using `python run.py` (default URL: [http://127.0.0.1:5000/](http://127.0.0.1:5000/))
 4. In `frontend/`, run `npm install` to install frontend packages.
 5. Launch the Svelte app with `npm run dev` and open [http://127.0.0.1:5173/](http://127.0.0.1:5173/).
-6. Admin endpoints require the `X-Admin-Password` header. The default password is `admin123`.
-7. The admin interface is available at `/admin` and requires the same password.
-8. The admin page also lets you create a new database by entering SQL or uploading a schema file.
-9. For OpenAI-assisted database generation create a `.env` file with `OPENAI_API_KEY=<your key>` and either run `python openai_db_creator.py` or use the admin page's "Create With OpenAI" form.
+6. Create a `.env` file with `ADMIN_PASSWORD=<your password>` (and any other environment settings).
+7. Admin endpoints require the `X-Admin-Password` header with the same password.
+8. The admin interface is available at `/admin` and requires the same password.
+9. The admin page also lets you create a new database by entering SQL or uploading a schema file.
+10. For OpenAI-assisted database generation add `OPENAI_API_KEY=<your key>` to `.env` and either run `python openai_db_creator.py` or use the admin page's "Create With OpenAI" form.

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -2,9 +2,15 @@
 
 from flask import Flask
 from flask_cors import CORS
+from dotenv import load_dotenv
 
 
 def create_app():
+    # Load variables from a .env file if present so environment configuration
+    # such as ADMIN_PASSWORD can be provided without setting system-wide
+    # variables.
+    load_dotenv()
+
     app = Flask(__name__)
     CORS(app)
 


### PR DESCRIPTION
## Summary
- load environment variables in `create_app()` so ADMIN_PASSWORD can be specified in a `.env` file
- update setup instructions to document ADMIN_PASSWORD in `.env`

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `npm run check` *(fails: svelte-check not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841f8cbebc4832184aae1947aa6525a