### PR TITLE
Improve admin DB list UI

### DIFF
--- a/frontend/src/Admin.svelte
+++ b/frontend/src/Admin.svelte
@@ -183,19 +183,34 @@ import { afterUpdate } from 'svelte'
   {:else}
     <button on:click={() => (loggedIn = false)}>Logout</button>
     <p>Active DB: {activeDb}</p>
-    <ul>
-      {#each dbs as db}
-        <li>
-          {db}
-          {#if db !== activeDb}
-            <button on:click={() => activate(db)}>Activate</button>
-          {/if}
-          {#if db !== 'playground.db'}
-            <button on:click={() => remove(db)}>Delete</button>
-          {/if}
-        </li>
-      {/each}
-    </ul>
+    <table class="db-table">
+      <thead>
+        <tr>
+          <th>Name</th>
+          <th>Status</th>
+          <th>Actions</th>
+        </tr>
+      </thead>
+      <tbody>
+        {#each dbs as db}
+          <tr class:active={db === activeDb}>
+            <td>{db}</td>
+            <td>
+              {#if db === activeDb}
+                Active
+              {:else}
+                <button on:click={() => activate(db)}>Activate</button>
+              {/if}
+            </td>
+            <td>
+              {#if db !== 'playground.db'}
+                <button on:click={() => remove(db)}>Delete</button>
+              {/if}
+            </td>
+          </tr>
+        {/each}
+      </tbody>
+    </table>
     <input
       type="file"
       accept=".db"
@@ -312,5 +327,22 @@ import { afterUpdate } from 'svelte'
     margin-top: 0.5rem;
     display: flex;
     gap: 0.5rem;
+  }
+
+  .db-table {
+    border-collapse: collapse;
+    margin-top: 0.5rem;
+    width: 100%;
+  }
+
+  .db-table th,
+  .db-table td {
+    border: 1px solid #ccc;
+    padding: 0.25rem 0.5rem;
+    text-align: left;
+  }
+
+  .db-table tr.active {
+    background-color: rgba(100, 108, 255, 0.2);
   }
 </style>


### PR DESCRIPTION
## Summary
- modernize the admin database list
- show databases in a table with Activate/Delete actions
- highlight the active database row with new styles

## Testing
- `npm run check`
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6841f8b1e7c483219599f5cfe636b36a