### PR TITLE
Show DB relationships in ER diagram

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -18,15 +18,32 @@
   let columns: string[] = []
   let error: string | null = null
 
-  function generateMermaid(tables: { name: string; columns: { name: string; type: string }[] }[]) {
-    const lines = ['erDiagram']
+  function generateMermaid(
+    tables: {
+      name: string
+      columns: { name: string; type: string }[]
+      foreign_keys?: { from: string; to_table: string; to_column: string }[]
+    }[]
+  ) {
+    const lines: string[] = ['erDiagram']
+    const relations = new Set<string>()
+
     for (const table of tables) {
       lines.push(`  ${table.name} {`)
       for (const col of table.columns) {
         lines.push(`    ${col.type} ${col.name}`)
       }
       lines.push('  }')
+
+      if (table.foreign_keys) {
+        for (const fk of table.foreign_keys) {
+          const rel = `${fk.to_table} ||--o{ ${table.name} : ${fk.from}`
+          relations.add(rel)
+        }
+      }
     }
+
+    relations.forEach((r) => lines.push(r))
     return lines.join('\n')
   }
 


### PR DESCRIPTION
## Summary
- include foreign keys in backend `/api/schema`
- render connections in ER diagram on the frontend using Mermaid

## Testing
- `python -m py_compile app/*.py openai_db_creator.py init_db.py run.py`
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6841fc2dd8b48321a5adc163ac61668d