### PR TITLE
Center results table and tweak page layout

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -123,7 +123,7 @@
   {/if}
   {#if results !== null}
     {#if results.length}
-      <table border="1">
+      <table class="results-table" border="1">
         <thead>
           <tr>
             {#each columns as col}
@@ -175,6 +175,11 @@
     align-items: center;
     justify-content: center;
     gap: 0.5rem;
+  }
+
+  .results-table {
+    margin-left: auto;
+    margin-right: auto;
   }
   .schema {
     margin-top: 0rem;

--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -25,7 +25,9 @@ a:hover {
 body {
   margin: 0;
   display: flex;
-  place-items: center;
+  justify-content: center;
+  align-items: flex-start;
+  padding-top: 1rem;
   min-width: 320px;
   min-height: 100vh;
 }


### PR DESCRIPTION
## Summary
- center the table displaying SQL query results
- move the page layout slightly higher by aligning body to the top

## Testing
- `npm run check`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6841fca4eba48321b186b906127dcc21